### PR TITLE
Order FASTA sequences and added warnings for CDS-prot mismatches

### DIFF
--- a/lib/phyTools.pm
+++ b/lib/phyTools.pm
@@ -522,6 +522,20 @@ sub read_FASTA_file_array
   close(FASTA);
 
   if($n_of_sequences == -1){ return \@FASTA }
+
+  # Sort sequences by name to have the same order between .faa and .fna.
+  @FASTA = sort {
+    # keep numeric names in ascending order, sort text as text
+    if (($a->[NAME] =~ m/^\d+$/) && ($b->[NAME] =~ m/^\d+$/))
+    {
+      return $a->[NAME] <=> $b->[NAME];
+    }
+    else
+    {
+      return $a->[NAME] cmp $b->[NAME];
+    }
+  } @FASTA;
+
   if($skipamino || $skipidentical)
   {
     my ($n_of_nr_sequences,@nrFASTA,%identical) = 0;


### PR DESCRIPTION
FASTA sequences are automatically ordered when loaded through read_FASTA_file_array() (either alphabetically or numerically according to sequence name nature)
get_homologues-est.pl warns when it detects CDS and protein sequences that do not appear to be matching.
When the sequence names are different (discarding FASTA sequence header comments) between .fna and .faa, the protein file will be discarded. If a sequence appears to be completely different in CDS or protein (protein not being a translation of a CDS since their length differ too much), just a warning is displayed for the sequence (bu the protein .faa is kept).