### PR TITLE
extract_features_from_genbank uses isolate as strain id, if strain is…

### DIFF
--- a/lib/phyTools.pm
+++ b/lib/phyTools.pm
@@ -923,6 +923,10 @@ sub extract_features_from_genbank
       {
         $strain = join(',',sort $f->each_tag_value('strain'));
       }
+      elsif($f->has_tag('isolate') and !$f->has_tag('strain'))
+      {
+              $strain = join(',',sort $f->each_tag_value('isolate')); 
+      }
       elsif($features_to_parse =~ $f->primary_tag())
       {
         $gi = $genename = $featseq = $rev = ''; # compatible con subrutina extract_CDS_from_genbank


### PR DESCRIPTION
extract_features_from_genbank in phyTools.pm now uses isolate as a strain ID if the strain attribute is undefined.